### PR TITLE
Refactor and focalloss added

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,18 +57,21 @@
 2. Model (-)
     * Unet (V)
     * anchor-base
-    * loss
-3. Public dataset (-)
+    * loss (V)
 
 ### Dataloader
 * Add segmentation augmentation in dataloader
 ### Model
-* Try Unet structure (V)
-    * Short-cut
-    * Transpose-conv -> Upsampling
+* Try Unet structure
+    * Short-cut (V)
+    * Transpose-conv -> Upsampling (V)
+    * anchor-base
 ### Loss
-* Try Dice loss, and/or tuning mask loss gain
-* Use Focal loss
+* Try Dice loss, and/or tuning mask loss gain (V)
+* Use Focal loss (V)
+
+#### Note
+BCE loss is useable for large artifial 
 
 ### Training
 * Support rect training or validation (masks and proto_out size should cautious)

--- a/models/common.py
+++ b/models/common.py
@@ -518,9 +518,13 @@ class Classify(nn.Module):
 
 
 if __name__ == "__main__":
+    from torch.utils.tensorboard import SummaryWriter
+
     x = torch.zeros((8, 128, 80, 80))
     shortcut_list = [torch.zeros(8, 64, 160, 160), torch.zeros(8, 32, 320, 320), torch.zeros(8, 3, 640, 640)]
     protonet = ProtoNet(c1=x.size(1))
-    print(protonet)
     y = protonet(x, shortcut_list)
     print(y.size())  # (8, 1, 640, 640)
+
+    with SummaryWriter('../runs/graph') as w:
+        w.add_graph(protonet, (x, shortcut_list,))

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -114,7 +114,10 @@ class Model(nn.Module):
         if isinstance(m, Detect):
             s = 256  # 2x min stride
             m.inplace = self.inplace
-            m.stride = torch.tensor([s / x.shape[-2] for x in self.forward(torch.zeros(1, ch, s, s))[0]])  # forward
+            if self.enable_seg:
+                m.stride = torch.tensor([s / x.shape[-2] for x in self.forward(torch.zeros(1, ch, s, s))[0]])  # forward
+            else:
+                m.stride = torch.tensor([s / x.shape[-2] for x in self.forward(torch.zeros(1, ch, s, s))])  # forward
             # modify above since if enable_seg is True, then there will be seg output
             m.anchors /= m.stride.view(-1, 1, 1)
             check_anchor_order(m)
@@ -253,7 +256,6 @@ class Model(nn.Module):
 
     def autoshape(self):  # add AutoShape module
         LOGGER.info('Adding AutoShape... ')
-        breakpoint()
         m = AutoShape(self, self.enable_seg)  # wrap model
         copy_attr(m, self, include=('yaml', 'nc', 'hyp', 'names', 'stride'), exclude=())  # copy attributes
         return m

--- a/train.py
+++ b/train.py
@@ -469,7 +469,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
 
 def parse_opt(known=False):
     parser = argparse.ArgumentParser()
-    parser.add_argument('--weights', type=str, default='yolov5s.pt', help='initial weights path')
+    parser.add_argument('--weights', type=str, default='runs/train/exp108/weights/best.pt', help='initial weights path')
     parser.add_argument('--cfg', type=str, default='yolov5s_seg.yaml', help='model.yaml path')
     parser.add_argument('--data', type=str, default=ROOT / 'data/green_data.yaml', help='dataset.yaml path')
     parser.add_argument('--hyp', type=str, default=ROOT / 'data/hyps/hyp.scratch.yaml', help='hyperparameters path')
@@ -502,8 +502,8 @@ def parse_opt(known=False):
     parser.add_argument('--save-period', type=int, default=-1, help='Save checkpoint every x epochs (disabled if < 1)')
     parser.add_argument('--local_rank', type=int, default=-1, help='DDP parameter, do not modify')
     parser.add_argument('--enable_seg', action='store_true', help='open mask data output')
-    parser.add_argument('--mask_loss_type', type=str, default='dicebce',
-                        help='there are ["bce", "dice", "dicebce"] mask loss type')
+    parser.add_argument('--mask_loss_type', type=str, default='dice',
+                        help='there are ["bce", "dice", "dicebce", "focalloss"] mask loss type')
     parser.add_argument('--ann-coco-path', type=str, default='/nfs/Workspace/defect_data/defect_seg_dataset/jsons/ann_coco.json', \
                         help='path to save ground truth annotation of COCO format')
     parser.add_argument('--mode', default='val', help='Mode of creating coco_json')

--- a/utils/coco.py
+++ b/utils/coco.py
@@ -81,6 +81,9 @@ def convert_jsons_to_coco_format(opt):
             points = sum(points, [])  # [x1, y1, x2, y2, ...]
             segmentation.append(points)
 
+        # If wish to use the artificial square for mAP sanity check, uncomment below
+        # segmentation.append([0, 0, 0, 400, 400, 400, 400, 0])  # add an artificial rectangle for test
+
         img_dict = {
             'id': i,
             'width': ann_json['imageWidth'],

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -565,6 +565,8 @@ class LoadImagesAndLabels(Dataset):
                 ori_mask = self.mask_files[index]
                 mask = resize_mask(self, ori_mask, output_size=(h, w))
                 mask = torch.from_numpy(mask.astype(np.float))
+                # If wish to use the artificial square for mAP sanity check, uncomment below
+                # mask[:400, :400] = 1
             else:
                 mask = None
 
@@ -629,7 +631,7 @@ class LoadImagesAndLabels(Dataset):
         img, label, path, shapes, mask = zip(*batch)  # transposed
         for i, l in enumerate(label):
             l[:, 0] = i  # add target image index for build_targets()
-        if mask is not None:
+        if mask[0] is not None:
             return torch.stack(img, 0), torch.cat(label, 0), path, shapes, torch.stack(mask, 0).unsqueeze(1)
         else:
             return torch.stack(img, 0), torch.cat(label, 0), path, shapes, None

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -114,8 +114,6 @@ class Annotator:
             output_mask = Image.fromarray(output_mask, mode='L')
             self.draw.bitmap((0, 0), output_mask, fill=(255, 0, 0, 128))
         else:
-            # if is_pred:
-            #     breakpoint()
             mask = Image.fromarray(mask * 255, mode='L')
             self.draw.bitmap((0, 0), mask, fill=(255, 0, 0, 128))
 
@@ -169,7 +167,7 @@ def thresholding_mask(masks, threshold=0.25):
 
 
 def plot_images(images, targets, paths=None, fname='images.jpg', names=None, masks=None, max_size=1920, max_subplots=16,
-                is_pred=False, mask_threshold=0.25):
+                is_pred=False, mask_threshold=0.5):
     '''Plot image grid with labels
     if plotting ground truth:
         - targets: (bz, [batch_id, class_id, x, y, w, h])
@@ -186,7 +184,7 @@ def plot_images(images, targets, paths=None, fname='images.jpg', names=None, mas
     if masks is not None:
         masks4plot = masks.cpu().numpy()
         if is_pred:
-            masks4plot = thresholding_mask(masks.cpu().numpy(), mask_threshold)
+            masks4plot = thresholding_mask(masks.sigmoid().cpu().numpy(), mask_threshold)
 
 
     bs, _, h, w = images.shape  # batch size, _, height, width
@@ -251,8 +249,10 @@ def plot_images(images, targets, paths=None, fname='images.jpg', names=None, mas
                     artifact_enlarge_space = 5
                     box = [b - artifact_enlarge_space if i <= 1 else b + artifact_enlarge_space for i, b in enumerate(box)]
                     annotator.box_label(box, label, color=color)
-                    if masks is not None:
-                        annotator.crop_mask(mosaic_mask, box, no_crop=True, is_pred=is_pred)
+        if masks is not None:
+            # if is_pred:
+            #     breakpoint()
+            annotator.crop_mask(mosaic_mask, box, no_crop=True, is_pred=is_pred)
     annotator.im.save(fname)  # save
 
 


### PR DESCRIPTION
1. fix bug in plots.py, now plot shows whenever there is mask
prediction, regardless detection or not. Visualization threshold is also
updated
2. focalloss added, change the alpha and gamma value in original yolov5
implementation. Mask loss is now only calculated once for one forward,
previous is decided by target anchor number.
3. add sanity check in datasets.py, also fixed the backward
compatible issue for detection only model training
4. add snaity check in coco.py
5. yolo.py also fixed the compatible issue
6. Add protonet visualization
7. val.py also fixed the compatible issue, and added sigmoid for model
output. Update the mask_conf_threshold for sanity check
8. train.py is now used train-detection-only weight, for solely training
protonet